### PR TITLE
move samples to use testcontainers instead of embedded mongo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <spring-boot23.version>2.4.13</spring-boot23.version>
         <spring-boot25.version>2.5.12</spring-boot25.version>
         <junit.version>5.8.2</junit.version>
+        <testcontainers.version>1.16.3</testcontainers.version>
 
         <java.version>1.8</java.version>
     </properties>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -23,4 +24,19 @@
         <module>spring-boot25-sync</module>
         <module>spring-boot25-reactive</module>
     </modules>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <version>${testcontainers.version}</version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/samples/spring-boot22-reactive/pom.xml
+++ b/samples/spring-boot22-reactive/pom.xml
@@ -27,11 +27,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>de.flapdoodle.embed</groupId>
-            <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/samples/spring-boot22-reactive/src/test/java/com/joom/mongoplanchecker/reactivestreams/sample/SampleTest.java
+++ b/samples/spring-boot22-reactive/src/test/java/com/joom/mongoplanchecker/reactivestreams/sample/SampleTest.java
@@ -8,13 +8,28 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
 
 @SpringBootTest
 class SampleTest {
+  private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2");
+
+  @DynamicPropertySource
+  static void setProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+  }
+
+  @BeforeAll
+  static void startMongo() {
+    mongoDBContainer.start();
+  }
 
   @Autowired private PlayerRepository repository;
   @Autowired private PlanChecker checker;

--- a/samples/spring-boot22-sync/pom.xml
+++ b/samples/spring-boot22-sync/pom.xml
@@ -27,11 +27,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>de.flapdoodle.embed</groupId>
-            <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 

--- a/samples/spring-boot22-sync/src/test/java/com/joom/mongoplanchecker/sync/sample/SampleTest.java
+++ b/samples/spring-boot22-sync/src/test/java/com/joom/mongoplanchecker/sync/sample/SampleTest.java
@@ -8,13 +8,28 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
 
 @SpringBootTest
 class SampleTest {
+  private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2");
+
+  @DynamicPropertySource
+  static void setProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+  }
+
+  @BeforeAll
+  static void startMongo() {
+    mongoDBContainer.start();
+  }
 
   @Autowired private PlayerRepository repository;
   @Autowired private PlanChecker checker;

--- a/samples/spring-boot23-reactive/pom.xml
+++ b/samples/spring-boot23-reactive/pom.xml
@@ -27,11 +27,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>de.flapdoodle.embed</groupId>
-            <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/samples/spring-boot23-reactive/src/test/java/com/joom/mongoplanchecker/reactivestreams/sample/SampleTest.java
+++ b/samples/spring-boot23-reactive/src/test/java/com/joom/mongoplanchecker/reactivestreams/sample/SampleTest.java
@@ -8,13 +8,28 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
 
 @SpringBootTest
 class SampleTest {
+  private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2");
+
+  @DynamicPropertySource
+  static void setProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+  }
+
+  @BeforeAll
+  static void startMongo() {
+    mongoDBContainer.start();
+  }
 
   @Autowired private PlayerRepository repository;
   @Autowired private PlanChecker checker;

--- a/samples/spring-boot23-sync/pom.xml
+++ b/samples/spring-boot23-sync/pom.xml
@@ -27,11 +27,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>de.flapdoodle.embed</groupId>
-            <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 

--- a/samples/spring-boot23-sync/src/test/java/com/joom/mongoplanchecker/sync/sample/SampleTest.java
+++ b/samples/spring-boot23-sync/src/test/java/com/joom/mongoplanchecker/sync/sample/SampleTest.java
@@ -8,13 +8,28 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
 
 @SpringBootTest
 class SampleTest {
+  private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2");
+
+  @DynamicPropertySource
+  static void setProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+  }
+
+  @BeforeAll
+  static void startMongo() {
+    mongoDBContainer.start();
+  }
 
   @Autowired private PlayerRepository repository;
   @Autowired private PlanChecker checker;

--- a/samples/spring-boot25-reactive/pom.xml
+++ b/samples/spring-boot25-reactive/pom.xml
@@ -27,11 +27,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>de.flapdoodle.embed</groupId>
-            <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/samples/spring-boot25-reactive/src/test/java/com/joom/mongoplanchecker/reactivestreams/sample/SampleTest.java
+++ b/samples/spring-boot25-reactive/src/test/java/com/joom/mongoplanchecker/reactivestreams/sample/SampleTest.java
@@ -8,13 +8,28 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
 
 @SpringBootTest
 class SampleTest {
+  private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2");
+
+  @DynamicPropertySource
+  static void setProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+  }
+
+  @BeforeAll
+  static void startMongo() {
+    mongoDBContainer.start();
+  }
 
   @Autowired private PlayerRepository repository;
   @Autowired private PlanChecker checker;

--- a/samples/spring-boot25-sync/pom.xml
+++ b/samples/spring-boot25-sync/pom.xml
@@ -27,11 +27,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>de.flapdoodle.embed</groupId>
-            <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 

--- a/samples/spring-boot25-sync/src/test/java/com/joom/mongoplanchecker/sync/sample/SampleTest.java
+++ b/samples/spring-boot25-sync/src/test/java/com/joom/mongoplanchecker/sync/sample/SampleTest.java
@@ -8,13 +8,28 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
 
 @SpringBootTest
 class SampleTest {
+  private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2");
+
+  @DynamicPropertySource
+  static void setProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+  }
+
+  @BeforeAll
+  static void startMongo() {
+    mongoDBContainer.start();
+  }
 
   @Autowired private PlayerRepository repository;
   @Autowired private PlanChecker checker;

--- a/testutil/pom.xml
+++ b/testutil/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.16.3</version>
+            <version>${testcontainers.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
It is strange to use two different technologies for main code and samples, especially since both of them require some manual additional setup (neither don't work out of the box on recent Macs). Let's get rid of embedded mongo and rely on testcontainers and dockerized mongo for both tests and main code. Though in tests I tried to use testcontainers in the most idiomatic way (maybe it is possible to simplify them even more)