### PR TITLE
add samples using spring boot 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <spring-boot22.version>2.2.13.RELEASE</spring-boot22.version>
         <spring-boot23.version>2.4.13</spring-boot23.version>
         <spring-boot25.version>2.5.14</spring-boot25.version>
+        <spring-boot3.version>3.0.1</spring-boot3.version>
         <junit.version>5.9.2</junit.version>
         <testcontainers.version>1.17.6</testcontainers.version>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -23,10 +23,21 @@
         <module>spring-boot23-reactive</module>
         <module>spring-boot25-sync</module>
         <module>spring-boot25-reactive</module>
-        <module>spring-boot3-sync</module>
-        <module>spring-boot3-reactive</module>
     </modules>
 
+
+    <profiles>
+        <profile>
+            <id>jadk17</id>
+            <activation>
+                <jdk>17</jdk>
+            </activation>
+            <modules>
+                <module>spring-boot3-sync</module>
+                <module>spring-boot3-reactive</module>
+            </modules>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -23,6 +23,8 @@
         <module>spring-boot23-reactive</module>
         <module>spring-boot25-sync</module>
         <module>spring-boot25-reactive</module>
+        <module>spring-boot3-sync</module>
+        <module>spring-boot3-reactive</module>
     </modules>
 
 

--- a/samples/spring-boot3-reactive/pom.xml
+++ b/samples/spring-boot3-reactive/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.joom.mongo-plan-checker</groupId>
+        <artifactId>mongo-plan-checker-samples</artifactId>
+        <version>0.0.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mongo-plan-checker-reactivestreams-spring-boot3-sample</artifactId>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb-reactive</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>mongo-plan-checker-reactivestreams-spring-data32</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot3.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/samples/spring-boot3-reactive/src/main/java/com/joom/mongoplanchecker/reactivestreams/sample/GameOfThronesPlayer.java
+++ b/samples/spring-boot3-reactive/src/main/java/com/joom/mongoplanchecker/reactivestreams/sample/GameOfThronesPlayer.java
@@ -1,0 +1,44 @@
+package com.joom.mongoplanchecker.reactivestreams.sample;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document
+public class GameOfThronesPlayer {
+  @Id private ObjectId id;
+  @Indexed private String house;
+  private String name;
+
+  public GameOfThronesPlayer() {}
+
+  public GameOfThronesPlayer(String house, String name) {
+    this.house = house;
+    this.name = name;
+  }
+
+  public ObjectId getId() {
+    return id;
+  }
+
+  public void setId(ObjectId id) {
+    this.id = id;
+  }
+
+  public String getHouse() {
+    return house;
+  }
+
+  public void setHouse(String house) {
+    this.house = house;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/samples/spring-boot3-reactive/src/main/java/com/joom/mongoplanchecker/reactivestreams/sample/PlayerRepository.java
+++ b/samples/spring-boot3-reactive/src/main/java/com/joom/mongoplanchecker/reactivestreams/sample/PlayerRepository.java
@@ -1,0 +1,11 @@
+package com.joom.mongoplanchecker.reactivestreams.sample;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import reactor.core.publisher.Mono;
+
+public interface PlayerRepository extends ReactiveMongoRepository<GameOfThronesPlayer, ObjectId> {
+  Mono<Long> countByName(String name);
+
+  Mono<Long> countByHouse(String house);
+}

--- a/samples/spring-boot3-reactive/src/main/java/com/joom/mongoplanchecker/reactivestreams/sample/SampleApplication.java
+++ b/samples/spring-boot3-reactive/src/main/java/com/joom/mongoplanchecker/reactivestreams/sample/SampleApplication.java
@@ -1,0 +1,6 @@
+package com.joom.mongoplanchecker.reactivestreams.sample;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SampleApplication {}

--- a/samples/spring-boot3-reactive/src/test/java/com/joom/mongoplanchecker/reactivestreams/sample/PlanCheckerConfig.java
+++ b/samples/spring-boot3-reactive/src/test/java/com/joom/mongoplanchecker/reactivestreams/sample/PlanCheckerConfig.java
@@ -1,0 +1,33 @@
+package com.joom.mongoplanchecker.reactivestreams.sample;
+
+import com.joom.mongoplanchecker.core.PlanChecker;
+import com.joom.mongoplanchecker.reactivestreams.data.PlanCheckerReactiveMongoDatabaseFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
+
+@Configuration
+public class PlanCheckerConfig {
+
+  @Bean
+  public PlanChecker planChecker() {
+    return new PlanChecker();
+  }
+
+  @Bean
+  public BeanPostProcessor mongoDbFactoryPostProcessor() {
+    return new BeanPostProcessor() {
+      @Override
+      public Object postProcessAfterInitialization(Object bean, String beanName)
+          throws BeansException {
+        if (bean instanceof ReactiveMongoDatabaseFactory) {
+          return new PlanCheckerReactiveMongoDatabaseFactory(
+              (ReactiveMongoDatabaseFactory) bean, planChecker());
+        }
+        return bean;
+      }
+    };
+  }
+}

--- a/samples/spring-boot3-reactive/src/test/java/com/joom/mongoplanchecker/reactivestreams/sample/SampleTest.java
+++ b/samples/spring-boot3-reactive/src/test/java/com/joom/mongoplanchecker/reactivestreams/sample/SampleTest.java
@@ -1,0 +1,74 @@
+package com.joom.mongoplanchecker.reactivestreams.sample;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.joom.mongoplanchecker.core.BadPlanException;
+import com.joom.mongoplanchecker.core.PlanChecker;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+
+@SpringBootTest
+class SampleTest {
+  private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2");
+
+  @DynamicPropertySource
+  static void setProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+  }
+
+  @BeforeAll
+  static void startMongo() {
+    mongoDBContainer.start();
+  }
+
+  @Autowired private PlayerRepository repository;
+  @Autowired private PlanChecker checker;
+
+  @BeforeEach
+  void setup() {
+    repository
+        .insert(
+            IntStream.range(0, 10)
+                .mapToObj(
+                    house ->
+                        IntStream.range(0, 3)
+                            .mapToObj(
+                                name -> new GameOfThronesPlayer("House" + house, "Name" + name)))
+                .flatMap(Function.identity())
+                .collect(Collectors.toList()))
+        .blockLast();
+  }
+
+  @Test
+  void testCountByName() {
+    assertThrows(BadPlanException.class, () -> repository.countByName("Name2").block());
+  }
+
+  @Test
+  void testCountByNameWithIgnore() {
+    checker.ignoreCollscan();
+    assertEquals(10, repository.countByName("Name2").block());
+  }
+
+  @Test
+  void testCountByHouse() {
+    assertEquals(3, repository.countByHouse("House7").block());
+  }
+
+  @AfterEach
+  void testDown() {
+    assertFalse(checker.anyIgnores());
+    // Have you ever run your tests against production DB?
+    repository.deleteAll().block();
+  }
+}

--- a/samples/spring-boot3-reactive/src/test/resources/application.properties
+++ b/samples/spring-boot3-reactive/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.data.mongodb.autoIndexCreation=true

--- a/samples/spring-boot3-sync/pom.xml
+++ b/samples/spring-boot3-sync/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.joom.mongo-plan-checker</groupId>
+        <artifactId>mongo-plan-checker-samples</artifactId>
+        <version>0.0.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mongo-plan-checker-sync-spring-boot3-sample</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>mongo-plan-checker-sync-spring-data32</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot25.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/samples/spring-boot3-sync/pom.xml
+++ b/samples/spring-boot3-sync/pom.xml
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot25.version}</version>
+                <version>${spring-boot3.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/samples/spring-boot3-sync/src/main/java/com/joom/mongoplanchecker/sync/sample/GameOfThronesPlayer.java
+++ b/samples/spring-boot3-sync/src/main/java/com/joom/mongoplanchecker/sync/sample/GameOfThronesPlayer.java
@@ -1,0 +1,44 @@
+package com.joom.mongoplanchecker.sync.sample;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document
+public class GameOfThronesPlayer {
+  @Id private ObjectId id;
+  @Indexed private String house;
+  private String name;
+
+  public GameOfThronesPlayer() {}
+
+  public GameOfThronesPlayer(String house, String name) {
+    this.house = house;
+    this.name = name;
+  }
+
+  public ObjectId getId() {
+    return id;
+  }
+
+  public void setId(ObjectId id) {
+    this.id = id;
+  }
+
+  public String getHouse() {
+    return house;
+  }
+
+  public void setHouse(String house) {
+    this.house = house;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/samples/spring-boot3-sync/src/main/java/com/joom/mongoplanchecker/sync/sample/PlayerRepository.java
+++ b/samples/spring-boot3-sync/src/main/java/com/joom/mongoplanchecker/sync/sample/PlayerRepository.java
@@ -1,0 +1,10 @@
+package com.joom.mongoplanchecker.sync.sample;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface PlayerRepository extends MongoRepository<GameOfThronesPlayer, ObjectId> {
+  Long countByName(String name);
+
+  Long countByHouse(String house);
+}

--- a/samples/spring-boot3-sync/src/main/java/com/joom/mongoplanchecker/sync/sample/SampleApplication.java
+++ b/samples/spring-boot3-sync/src/main/java/com/joom/mongoplanchecker/sync/sample/SampleApplication.java
@@ -1,0 +1,6 @@
+package com.joom.mongoplanchecker.sync.sample;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SampleApplication {}

--- a/samples/spring-boot3-sync/src/test/java/com/joom/mongoplanchecker/sync/sample/PlanCheckerConfig.java
+++ b/samples/spring-boot3-sync/src/test/java/com/joom/mongoplanchecker/sync/sample/PlanCheckerConfig.java
@@ -1,0 +1,32 @@
+package com.joom.mongoplanchecker.sync.sample;
+
+import com.joom.mongoplanchecker.core.PlanChecker;
+import com.joom.mongoplanchecker.sync.data.PlanCheckerMongoDatabaseFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+
+@Configuration
+public class PlanCheckerConfig {
+
+  @Bean
+  public PlanChecker planChecker() {
+    return new PlanChecker();
+  }
+
+  @Bean
+  public BeanPostProcessor mongoDatabaseFactoryPostProcessor() {
+    return new BeanPostProcessor() {
+      @Override
+      public Object postProcessAfterInitialization(Object bean, String beanName)
+          throws BeansException {
+        if (bean instanceof MongoDatabaseFactory) {
+          return new PlanCheckerMongoDatabaseFactory((MongoDatabaseFactory) bean, planChecker());
+        }
+        return bean;
+      }
+    };
+  }
+}

--- a/samples/spring-boot3-sync/src/test/java/com/joom/mongoplanchecker/sync/sample/SampleTest.java
+++ b/samples/spring-boot3-sync/src/test/java/com/joom/mongoplanchecker/sync/sample/SampleTest.java
@@ -1,0 +1,71 @@
+package com.joom.mongoplanchecker.sync.sample;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.joom.mongoplanchecker.core.BadPlanException;
+import com.joom.mongoplanchecker.core.PlanChecker;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+
+@SpringBootTest
+class SampleTest {
+  private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2");
+
+  @DynamicPropertySource
+  static void setProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+  }
+
+  @BeforeAll
+  static void startMongo() {
+    mongoDBContainer.start();
+  }
+
+  @Autowired private PlayerRepository repository;
+  @Autowired private PlanChecker checker;
+
+  @BeforeEach
+  void setup() {
+    repository.insert(
+        IntStream.range(0, 10)
+            .mapToObj(
+                house ->
+                    IntStream.range(0, 3)
+                        .mapToObj(name -> new GameOfThronesPlayer("House" + house, "Name" + name)))
+            .flatMap(Function.identity())
+            .collect(Collectors.toList()));
+  }
+
+  @Test
+  void testCountByName() {
+    assertThrows(BadPlanException.class, () -> repository.countByName("Name2"));
+  }
+
+  @Test
+  void testCountByNameWithIgnore() {
+    checker.ignoreCollscan();
+    assertEquals(10, repository.countByName("Name2"));
+  }
+
+  @Test
+  void testCountByHouse() {
+    assertEquals(3, repository.countByHouse("House7"));
+  }
+
+  @AfterEach
+  void testDown() {
+    assertFalse(checker.anyIgnores());
+    // Have you ever run your tests against production DB?
+    repository.deleteAll();
+  }
+}

--- a/samples/spring-boot3-sync/src/test/resources/application.properties
+++ b/samples/spring-boot3-sync/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.data.mongodb.autoIndexCreation=true


### PR DESCRIPTION
It seems that backward compatibility in driver, spring-data and spring-boot is in place and we do not need separate support for the latest versions - lets ensure it with samples and tests in samples at least.

Note: these samples are conditionally built only on java17